### PR TITLE
Revert "Allow unsupported arguments in entrypoint methods"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Revert: Allow unsupported arguments in entrypoint methods (:pr:`62`)
+
 0.0.5 (20-05-2026)
 ------------------
+* Allow unsupported arguments in entrypoint methods (:pr:`61`)
 * Add a TTL to Multiton instances
 
 0.0.4 (31-03-2026)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,7 @@ Changelog
 
 0.0.5 (20-05-2026)
 ------------------
-* Allow unsupported arguments in entrypoint methods (:pr:`61`)
-* Add a TTL to Multiton instances (:pr:`60`)
+* Add a TTL to Multiton instances
 
 0.0.4 (31-03-2026)
 ------------------

--- a/src/xarray_kat/entrypoint.py
+++ b/src/xarray_kat/entrypoint.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import os
-import warnings
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Tuple
 from urllib.parse import SplitResult, parse_qs, urlsplit
@@ -17,7 +16,6 @@ if TYPE_CHECKING:
 
 
 from xarray_kat.datatree_factory import DataTreeFactory
-from xarray_kat.errors import IgnoredArgument
 from xarray_kat.katdal_types import TelstateDataProducts, TelstateDataSource
 from xarray_kat.multiton import Multiton
 from xarray_kat.xkat_types import UvwSignConventionType, VanVleckLiteralType
@@ -89,7 +87,6 @@ class KatEntryPoint(BackendEntrypoint):
     stream_name: str | None = None,
     uvw_sign_convention: UvwSignConventionType = "casa",
     van_vleck: VanVleckLiteralType = "off",
-    **kwargs,
   ):
     """Open a MeerKAT observation as an :class:`xarray.DataTree`.
 
@@ -140,7 +137,6 @@ class KatEntryPoint(BackendEntrypoint):
       stream_name=stream_name,
       uvw_sign_convention=uvw_sign_convention,
       van_vleck=van_vleck,
-      **kwargs,
     )
     return DataTree.from_dict(group_dicts)
 
@@ -156,15 +152,7 @@ class KatEntryPoint(BackendEntrypoint):
     stream_name: str | None = None,
     uvw_sign_convention: UvwSignConventionType = "casa",
     van_vleck: VanVleckLiteralType = "off",
-    **kwargs,
   ) -> Dict[str, Any]:
-    if kwargs:
-      warnings.warn(
-        f"xarray-kat does not support the following arguments and will ignore them: "
-        f"{sorted(kwargs)}",
-        IgnoredArgument,
-        stacklevel=2,
-      )
     url = str(filename_or_obj)
     urlbits = urlsplit(url)
     assert urlbits.scheme in {"http", "https"}

--- a/src/xarray_kat/errors.py
+++ b/src/xarray_kat/errors.py
@@ -4,7 +4,3 @@ class InvalidJwtToken(ValueError):
 
 class TelstateKeyError(ValueError):
   """Raised if some required key is not present in the telescope state"""
-
-
-class IgnoredArgument(UserWarning):
-  """Issued when keyword arguments are passed that this backend does not support."""

--- a/tests/test_mock_http_server.py
+++ b/tests/test_mock_http_server.py
@@ -422,31 +422,6 @@ class TestXarrayKatIntegration:
       assert "VISIBILITY" in ds
       assert "time" in ds.dims
 
-  def test_ignored_kwargs_warning(self, httpserver: HTTPServer, tmp_path):
-    """Unsupported xarray kwargs trigger IgnoredArgument, but the tree still loads."""
-    import warnings
-
-    from xarray_kat.errors import IgnoredArgument
-
-    obs = SyntheticObservation("1234567890", ntime=8, nfreq=16, nants=4)
-    obs.add_scan(range(0, 8), "track", "PKS1934")
-    obs.save_to_directory(tmp_path)
-
-    token = setup_mock_archive_server(
-      httpserver, tmp_path, "1234567890", require_auth=True
-    )
-    base_url = httpserver.url_for("/")
-    rdb_url = f"{base_url}1234567890/1234567890_sdp_l0.full.rdb?token={token}"
-
-    with warnings.catch_warnings(record=True) as caught:
-      warnings.simplefilter("always")
-      dt = xarray.open_datatree(rdb_url, engine="xarray-kat", unsupported_kwarg=True)
-
-    ignored = [w for w in caught if issubclass(w.category, IgnoredArgument)]
-    assert len(ignored) == 1
-    assert "unsupported_kwarg" in str(ignored[0].message)
-    assert len(dt.children) > 0
-
   def test_field_and_source_xds_dataset(self, httpserver: HTTPServer, tmp_path):
     """Test field_and_source_xds structure and values"""
     from tests.conftest import DEFAULT_COORDS


### PR DESCRIPTION
Reverts ratt-ru/xarray-kat#61 following discussions surrounding supporting implicit vs explicit arguments with @landmanbester.


In particular xarray-kat currently uses a specific set of arguments: `xarray.open_datatree(..., chunked_array_type="xarray-kat", chunks={})` that could conflict with other xarray backends. i.e. `xarray-ms` could end up using the `xarray-kat` **chunked_array_type**.

Thus we'll need to explicitly set arguments to the different xarray backends and differentiate the cases with msv4-utils.