### PR TITLE
Fix uvw sign convention

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Fix computation of uvw sign convention
 * Output active calibration corrections in katdal comparison script (:pr:`66`)
 * Add a script for comparing MSv4 DataTree values against a katdal dataset (:pr:`65`)
 * Add multiple scans to the katdal comparison test case (:pr:`64`)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
-* Fix computation of uvw sign convention
+* Fix sign convention of UVW coordinates (:pr:`68`)
 * Output active calibration corrections in katdal comparison script (:pr:`66`)
 * Add a script for comparing MSv4 DataTree values against a katdal dataset (:pr:`65`)
 * Add multiple scans to the katdal comparison test case (:pr:`64`)

--- a/src/xarray_kat/datatree_factory.py
+++ b/src/xarray_kat/datatree_factory.py
@@ -391,8 +391,8 @@ class DataTreeFactory:
     ant2_names = np.array(cp_ant2_names[:: len(upols)], dtype=str)
     concat_ant_names = np.concatenate([ant1_names, ant2_names])
     _, inv = np.unique(concat_ant_names, return_inverse=True)
-    ant1_index = inv[len(inv) // 2 :]
-    ant2_index = inv[: len(inv) // 2]
+    ant1_index = inv[: len(inv) // 2]
+    ant2_index = inv[len(inv) // 2 :]
 
     pols = np.array([HV_TO_LINEAR_MAP[p] for p in cp_pols[: len(upols)]], dtype=str)
 

--- a/tests/test_katdal.py
+++ b/tests/test_katdal.py
@@ -69,6 +69,6 @@ class TestKatdal:
 
       xarray_kat_uvw = node.UVW.data
       katdal_uvw = np.stack([ds.u, ds.v, ds.w], axis=2)[:, obs.corrprod_argsort]
-      if uvw_sign_convention == "casa":
+      if uvw_sign_convention == "fourier":
         katdal_uvw = -katdal_uvw
       np.testing.assert_allclose(xarray_kat_uvw, katdal_uvw[:, :: obs.npol])


### PR DESCRIPTION
This was detected in:

- https://github.com/ratt-ru/pfb-imaging/pull/245#issuecomment-4574220662

`ant1_index` and `ant2_index` were inverted

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-kat/issues/new/choose

-->

Thanks for contributing to xarray-kat.

We would appreciate it if you could add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.
