### PR TITLE
Fix lifecycle bugs in AsyncLoopSingleton

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Fix lifecycle bugs in AsyncLoopSingleton (:pr:`70`)
 * Removed ``interleaved_vfw_store`` (:pr:`69`)
 
 0.0.6 (29-05-2026)

--- a/src/xarray_kat/async_loop.py
+++ b/src/xarray_kat/async_loop.py
@@ -43,46 +43,71 @@ def _run_loop_in_thread(
     log.debug("Done")
 
 
+class _LoopState:
+  """Mutable loop/thread state shared between the singleton and its finalizer.
+
+  Kept separate from ``AsyncLoopSingleton`` so the ``weakref.finalize`` callback
+  can reference this state instead of a bound method of the instance (which would
+  create a strong self-reference and prevent the instance from being collected).
+  """
+
+  __slots__ = ("loop", "thread", "lock", "running")
+
+  def __init__(self) -> None:
+    self.loop: asyncio.AbstractEventLoop | None = None
+    self.thread: threading.Thread | None = None
+    self.lock = threading.Lock()
+    self.running = threading.Event()
+
+
+def _close_state(state: _LoopState) -> None:
+  with state.lock:
+    thread, loop = state.thread, state.loop
+    if not thread or not loop:
+      return
+
+    if loop.is_running():
+      loop.call_soon_threadsafe(loop.stop)
+
+    # A thread cannot join itself; calling close() from a coroutine running on
+    # the loop thread would otherwise deadlock (while holding state.lock).
+    if thread is not threading.current_thread():
+      thread.join()
+
+    state.thread = None
+    state.loop = None
+
+
 class AsyncLoopSingleton(metaclass=Singleton):
-  _loop: asyncio.AbstractEventLoop | None
-  _thread: threading.Thread | None
-  _lock: threading.Lock
-  _running: threading.Event
+  _state: _LoopState
 
   def __init__(self):
-    self._loop = None
-    self._thread = None
-    self._lock = threading.Lock()
-    self._running = threading.Event()
-    weakref.finalize(self, self.close)
+    self._state = _LoopState()
+    weakref.finalize(self, _close_state, self._state)
     self.start()
 
   @property
   def instance(self):
-    return self._loop
+    return self._state.loop
 
   def start(self) -> None:
-    with self._lock:
-      if self._thread and self._thread.is_alive():
+    state = self._state
+    with state.lock:
+      if state.thread and state.thread.is_alive():
         return
 
-      self._loop = asyncio.new_event_loop()
-      self._thread = threading.Thread(
+      state.running.clear()
+      state.loop = asyncio.new_event_loop()
+      state.thread = threading.Thread(
         target=_run_loop_in_thread,
-        args=(self._loop, self._running),
+        args=(state.loop, state.running),
         daemon=True,
         name="AsyncLoopThread",
       )
-      self._thread.start()
+      state.thread.start()
+      # Don't return until run_forever() is actually driving the loop, so
+      # callers of .instance never see a not-yet-running loop.
+      state.running.wait()
 
   def close(self) -> None:
-    with self._lock:
-      if not self._thread or not self._loop:
-        return
-
-      if self._loop.is_running():
-        self._loop.call_soon_threadsafe(self._loop.stop)
-
-      self._thread.join()
-      self._thread = None
-      self._loop = None
+    _close_state(self._state)

--- a/tests/test_async_loop.py
+++ b/tests/test_async_loop.py
@@ -1,22 +1,219 @@
 import asyncio
 import gc
+import threading
+import weakref
 
-from xarray_kat.async_loop import AsyncLoopSingleton
+import pytest
+
+from xarray_kat.async_loop import (
+  AsyncLoopSingleton,
+  Singleton,
+  _close_state,
+  _LoopState,
+)
 
 
-def test_async_loop_manager_singleton():
+@pytest.fixture(autouse=True)
+def reset_singleton():
+  """Give every test a fresh AsyncLoopSingleton.
+
+  AsyncLoopSingleton lives in the Singleton metaclass cache, so without this
+  one test's close()/restart would leak loop+thread state into the next.
+  """
+
+  def _reset():
+    instance = Singleton._instances.pop(AsyncLoopSingleton, None)
+    if instance is not None:
+      instance.close()
+
+  _reset()
+  yield
+  _reset()
+
+
+# ---------------------------------------------------------------------------
+# Singleton metaclass
+# ---------------------------------------------------------------------------
+
+
+def test_singleton_returns_same_instance():
+  assert AsyncLoopSingleton() is AsyncLoopSingleton()
   assert AsyncLoopSingleton().instance is AsyncLoopSingleton().instance
 
 
-def test_sync_coroutine():
-  async def f(a):
+def test_concurrent_construction_yields_single_instance():
+  """The double-checked lock in Singleton.__call__ must hand every racing
+  thread the same instance (and start exactly one loop thread)."""
+  n = 8
+  barrier = threading.Barrier(n)
+  results: list[AsyncLoopSingleton] = []
+  lock = threading.Lock()
+
+  def make():
+    barrier.wait()
+    inst = AsyncLoopSingleton()
+    with lock:
+      results.append(inst)
+
+  threads = [threading.Thread(target=make) for _ in range(n)]
+  for t in threads:
+    t.start()
+  for t in threads:
+    t.join()
+
+  assert len(results) == n
+  assert len({id(r) for r in results}) == 1
+  # Exactly one background loop thread was spawned.
+  loop_threads = [t for t in threading.enumerate() if t.name == "AsyncLoopThread"]
+  assert len(loop_threads) == 1
+
+
+# ---------------------------------------------------------------------------
+# start() / running loop
+# ---------------------------------------------------------------------------
+
+
+def test_instance_is_a_running_loop_on_construction():
+  """start() waits on the running event, so .instance is never observed
+  before run_forever() is actually driving the loop."""
+  singleton = AsyncLoopSingleton()
+  assert isinstance(singleton.instance, asyncio.AbstractEventLoop)
+  assert singleton.instance.is_running()
+  assert singleton._state.running.is_set()
+
+
+def test_loop_runs_in_dedicated_daemon_thread():
+  singleton = AsyncLoopSingleton()
+  thread = singleton._state.thread
+  assert thread is not None
+  assert thread.is_alive()
+  assert thread.daemon
+  assert thread.name == "AsyncLoopThread"
+  assert thread is not threading.current_thread()
+
+
+def test_start_is_idempotent_while_running():
+  """Calling start() again on a live loop is a no-op: same loop, same thread,
+  no extra thread spawned."""
+  singleton = AsyncLoopSingleton()
+  loop, thread = singleton.instance, singleton._state.thread
+
+  singleton.start()
+
+  assert singleton.instance is loop
+  assert singleton._state.thread is thread
+  loop_threads = [t for t in threading.enumerate() if t.name == "AsyncLoopThread"]
+  assert len(loop_threads) == 1
+
+
+# ---------------------------------------------------------------------------
+# coroutine execution
+# ---------------------------------------------------------------------------
+
+
+def test_run_coroutine_returns_result():
+  async def add_one(a):
     return a + 1
 
-  def test():
-    assert (
-      asyncio.run_coroutine_threadsafe(f(2), AsyncLoopSingleton().instance).result()
-      == 3
-    )
+  loop = AsyncLoopSingleton().instance
+  assert asyncio.run_coroutine_threadsafe(add_one(2), loop).result(timeout=5) == 3
 
-  test()
+
+def test_coroutine_exception_propagates():
+  async def boom():
+    raise ValueError("nope")
+
+  loop = AsyncLoopSingleton().instance
+  fut = asyncio.run_coroutine_threadsafe(boom(), loop)
+  with pytest.raises(ValueError, match="nope"):
+    fut.result(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+def test_close_stops_thread_and_clears_state():
+  singleton = AsyncLoopSingleton()
+  thread = singleton._state.thread
+
+  singleton.close()
+
+  thread.join(timeout=5)
+  assert not thread.is_alive()
+  assert singleton.instance is None
+  assert singleton._state.thread is None
+  assert not singleton._state.running.is_set()
+
+
+def test_close_is_idempotent():
+  singleton = AsyncLoopSingleton()
+  singleton.close()
+  singleton.close()  # must not raise
+  assert singleton.instance is None
+
+
+def test_close_state_no_op_when_never_started():
+  """_close_state on fresh state (loop/thread still None) returns early."""
+  state = _LoopState()
+  _close_state(state)  # must not raise
+  assert state.loop is None
+  assert state.thread is None
+
+
+def test_restart_after_close():
+  singleton = AsyncLoopSingleton()
+  old_loop = singleton.instance
+  singleton.close()
+  assert singleton.instance is None
+
+  singleton.start()
+  new_loop = singleton.instance
+  assert new_loop is not None
+  assert new_loop is not old_loop
+  assert new_loop.is_running()
+
+  async def answer():
+    return 42
+
+  assert asyncio.run_coroutine_threadsafe(answer(), new_loop).result(timeout=5) == 42
+
+
+def test_close_from_loop_thread_does_not_deadlock():
+  """Closing from a coroutine running on the loop thread must not self-join
+  deadlock while holding the state lock."""
+  singleton = AsyncLoopSingleton()
+  loop = singleton.instance
+
+  async def close_from_inside():
+    singleton.close()
+
+  fut = asyncio.run_coroutine_threadsafe(close_from_inside(), loop)
+  fut.result(timeout=5)  # hangs (and times out) if the self-join deadlock regresses
+
+  assert singleton.instance is None
+
+
+# ---------------------------------------------------------------------------
+# finalizer
+# ---------------------------------------------------------------------------
+
+
+def test_finalizer_collects_instance_and_closes_loop():
+  """The finalizer targets a free function over _LoopState, not a bound
+  method, so the instance is collectable; collection then tears down the
+  loop thread."""
+  singleton = AsyncLoopSingleton()
+  thread = singleton._state.thread
+  ref = weakref.ref(singleton)
+
+  # Drop the only strong references (cache + local) so the instance can die.
+  Singleton._instances.pop(AsyncLoopSingleton, None)
+  del singleton
   gc.collect()
+
+  # Instance was actually collected (pre-fix regression: leaked via bound method).
+  assert ref() is None
+  thread.join(timeout=5)
+  assert not thread.is_alive()  # finalizer ran and tore down the loop


### PR DESCRIPTION
Move the loop/thread/lock/event into a separate _LoopState holder shared between the singleton and its finalizer. This fixes four issues:

- Finalizer no longer leaks the instance: weakref.finalize previously targeted the bound method self.close, creating a strong self-reference that prevented garbage collection and stopped the finalizer from ever running outside interpreter exit. It now targets a free function over _LoopState instead.

- Avoid self-join deadlock: _close_state skips thread.join() when called from the loop thread itself, so closing from a coroutine on that thread no longer deadlocks while holding the lock.

- start() now waits on the running event before returning, so callers of .instance never observe a loop whose run_forever() hasn't begun.

- The running event is now actually consumed (cleared on (re)start and waited on) rather than being set/cleared with no reader.

Public API (AsyncLoopSingleton(), .instance, .start(), .close()) is unchanged.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/xarray-kat/issues/new/choose

-->

Thanks for contributing to xarray-kat.

We would appreciate it if you could add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `doc/source/changelog.rst`.
