### PR TITLE
Pin numpy<2.5 to work around katpoint np.row_stack removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "katpoint>=0.10.2",
+    # katpoint 0.10.2 (latest release) calls np.row_stack in Target.uvw_basis,
+    # which numpy 2.5.0 removed. Fixed upstream in ska-sa/katpoint 122f90d8
+    # ("Replace deprecated row_stack with vstack"), but unreleased.
+    # Drop this pin once a katpoint release containing that fix is available.
+    "numpy<2.5",
     "katsdptelstate[rdb]>=1.0.0",
     "rarg-python-patterns>=0.0.1",
     "tensorstore>=0.1.81",


### PR DESCRIPTION
## Diagnosis

The scheduled CI run [#31663455147](https://github.com/ratt-ru/xarray-kat/actions/runs/31663455147) failed on every Python 3.12/3.13/3.14 job (3.11 was green) with a single root cause:

```
.venv/lib/python3.13/site-packages/xarray_kat/datatree_factory.py:478: in create
    uvw_ant = target.uvw(antennas, scan_timestamps, array_centre)
.venv/lib/python3.13/site-packages/katpoint/target.py:661: in uvw_basis
    u = np.row_stack(np.cross(z, w, axis=0)) * offset_sign
E   AttributeError: module 'numpy' has no attribute 'row_stack'
```

`np.row_stack` was deprecated in numpy 2.0 and **removed in numpy 2.5.0** (verified: it still exists in 2.4.6). numpy 2.5 requires Python >= 3.12, so the 3.11 jobs resolved to 2.4.x and passed while everything else picked up 2.5.2 (released 2026-08-09, four days before the failing run).

The call site is in `katpoint`, not in this repo. `katpoint` fixed it upstream in [`122f90d8`](https://github.com/ska-sa/katpoint/commit/122f90d8) ("SPR1-3236 Replace deprecated row_stack with vstack", June 2025), but no release contains it — 0.10.2 (Oct 2024) is still the latest on PyPI.

All 23 failures on 3.12/3.13 and all 14 on 3.14 trace to this one attribute; no other errors were present.

## Fix

Add `numpy<2.5` to `[project].dependencies`, with a comment naming the upstream fix so the pin can be dropped once katpoint cuts a release. numpy is imported directly by `xarray_kat` anyway, so declaring it explicitly is correct regardless.

This is a genuine runtime incompatibility, not just a test-environment issue — UVW computation is core functionality, so any user on numpy >= 2.5 hits it. The constraint therefore belongs in the runtime dependencies rather than the test group.

## Verification

Full suite run locally on all four matrix Python versions (resolves to numpy 2.4.6):

| Python | Result |
|--------|--------|
| 3.11 | 82 passed, 3 skipped |
| 3.12 | 82 passed, 3 skipped |
| 3.13 | 82 passed, 3 skipped |
| 3.14 | 73 passed, 5 skipped |

Confirmed the failure reproduces on 3.13 before the change. `uv run --dev pre-commit run -a` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)